### PR TITLE
Ma 340 add event for on bot close

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,15 @@ Bot can be programatically closed using `closeBot()` function
 ymChat.closeBot();
 ```
 
+## Bot close event
+Bot close event is separetly sent and it can be handled by listening to onBotClose event as mentioned below.
+
+```java
+ymChat.onBotClose(() -> {
+  Log.d("Example App", "Bot Was closed");
+ });
+```
+
 ## Events from bot
 Events from bot can be handled using event Listeners.  Simply define the `onSuccess` method of `onEventFromBot` listener.
 

--- a/YMChat/src/main/java/com/yellowmessenger/ymchat/BotCloseEventListener.java
+++ b/YMChat/src/main/java/com/yellowmessenger/ymchat/BotCloseEventListener.java
@@ -1,0 +1,5 @@
+package com.yellowmessenger.ymchat;
+
+public interface BotCloseEventListener {
+    void onClosed();
+}

--- a/YMChat/src/main/java/com/yellowmessenger/ymchat/BotEventListener.java
+++ b/YMChat/src/main/java/com/yellowmessenger/ymchat/BotEventListener.java
@@ -4,5 +4,4 @@ import com.yellowmessenger.ymchat.models.YMBotEventResponse;
 
 public interface BotEventListener {
     void onSuccess(YMBotEventResponse botEvent);
-//    void onFailure(String error);
 }

--- a/YMChat/src/main/java/com/yellowmessenger/ymchat/BotWebView.java
+++ b/YMChat/src/main/java/com/yellowmessenger/ymchat/BotWebView.java
@@ -176,8 +176,8 @@ public class BotWebView extends AppCompatActivity {
             switch (botEvent.getCode()) {
                 case "close-bot":
                     closeBot();
-                    this.finish();
                     YMChat.getInstance().emitEvent(new YMBotEventResponse("bot-closed", ""));
+                    this.finish();
                     break;
                 case "upload-image":
                     Log.d(TAG, "onSuccess: got event");

--- a/YMChat/src/main/java/com/yellowmessenger/ymchat/BotWebView.java
+++ b/YMChat/src/main/java/com/yellowmessenger/ymchat/BotWebView.java
@@ -177,6 +177,7 @@ public class BotWebView extends AppCompatActivity {
                 case "close-bot":
                     closeBot();
                     this.finish();
+                    YMChat.getInstance().emitEvent(new YMBotEventResponse("bot-closed", ""));
                     break;
                 case "upload-image":
                     Log.d(TAG, "onSuccess: got event");

--- a/YMChat/src/main/java/com/yellowmessenger/ymchat/YMChat.java
+++ b/YMChat/src/main/java/com/yellowmessenger/ymchat/YMChat.java
@@ -10,7 +10,8 @@ import com.yellowmessenger.ymchat.models.YMBotEventResponse;
 
 public class YMChat {
     private final String TAG = "YMChat";
-    private BotEventListener listener, localListener, botCloseEventListener;
+    private BotEventListener listener, localListener;
+    private BotCloseEventListener botCloseEventListener;
     private static YMChat botPluginInstance;
     public YMConfig config;
 
@@ -37,7 +38,7 @@ public class YMChat {
     public void onEventFromBot(BotEventListener listener) {
         this.listener = listener;
     }
-    public void onBotClose(BotEventListener listener) {
+    public void onBotClose(BotCloseEventListener listener) {
         this.botCloseEventListener = listener;
     }
 
@@ -68,7 +69,7 @@ public class YMChat {
     public void emitEvent(YMBotEventResponse event) {
         if (event != null) {
             if(botCloseEventListener!= null && event.getCode().equals("bot-closed")){
-                botCloseEventListener.onSuccess(event);
+                botCloseEventListener.onClosed();
             }
             else{
                 if (listener != null)

--- a/YMChat/src/main/java/com/yellowmessenger/ymchat/YMChat.java
+++ b/YMChat/src/main/java/com/yellowmessenger/ymchat/YMChat.java
@@ -10,7 +10,7 @@ import com.yellowmessenger.ymchat.models.YMBotEventResponse;
 
 public class YMChat {
     private final String TAG = "YMChat";
-    private BotEventListener listener, localListener;
+    private BotEventListener listener, localListener, botCloseEventListener;
     private static YMChat botPluginInstance;
     public YMConfig config;
 
@@ -36,6 +36,9 @@ public class YMChat {
 
     public void onEventFromBot(BotEventListener listener) {
         this.listener = listener;
+    }
+    public void onBotClose(BotEventListener listener) {
+        this.botCloseEventListener = listener;
     }
 
     public void startChatbot(Context context) {
@@ -64,11 +67,17 @@ public class YMChat {
 
     public void emitEvent(YMBotEventResponse event) {
         if (event != null) {
-            if (listener != null)
-                listener.onSuccess(event);
+            if(botCloseEventListener!= null && event.getCode().equals("bot-closed")){
+                botCloseEventListener.onSuccess(event);
+            }
+            else{
+                if (listener != null)
+                    listener.onSuccess(event);
 
-            if (localListener != null)
-                localListener.onSuccess(event);
+                if (localListener != null)
+                    localListener.onSuccess(event);
+            }
+
         }
     }
 

--- a/YMChat/src/main/java/com/yellowmessenger/ymchat/YMChat.java
+++ b/YMChat/src/main/java/com/yellowmessenger/ymchat/YMChat.java
@@ -68,7 +68,7 @@ public class YMChat {
 
     public void emitEvent(YMBotEventResponse event) {
         if (event != null) {
-            if(botCloseEventListener!= null && event.getCode().equals("bot-closed")){
+            if(botCloseEventListener!= null && event.getCode() !=null && event.getCode().equals("bot-closed")){
                 botCloseEventListener.onClosed();
             }
             else{

--- a/app/src/main/java/com/yellowmessenger/ymchatexample/MainActivity.java
+++ b/app/src/main/java/com/yellowmessenger/ymchatexample/MainActivity.java
@@ -1,6 +1,7 @@
 package com.yellowmessenger.ymchatexample;
 
 import android.os.Bundle;
+import android.util.Log;
 import android.webkit.JavascriptInterface;
 
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
@@ -35,6 +36,10 @@ public class MainActivity extends AppCompatActivity {
             switch (botEvent.getCode()){
                 case "event-name": break;
             }
+        });
+        ymChat.onBotClose((YMBotEventResponse botEvent) -> {
+            Log.d("Example App", "Bot Was closed");
+
         });
 
         setContentView(R.layout.activity_main);

--- a/app/src/main/java/com/yellowmessenger/ymchatexample/MainActivity.java
+++ b/app/src/main/java/com/yellowmessenger/ymchatexample/MainActivity.java
@@ -37,9 +37,8 @@ public class MainActivity extends AppCompatActivity {
                 case "event-name": break;
             }
         });
-        ymChat.onBotClose((YMBotEventResponse botEvent) -> {
+        ymChat.onBotClose(() -> {
             Log.d("Example App", "Bot Was closed");
-
         });
 
         setContentView(R.layout.activity_main);


### PR DESCRIPTION
Can listen to botClose events now.
example: 
```java
        ymChat.onBotClose((YMBotEventResponse botEvent) -> {
            Log.d("Example App", "Bot Was closed");
        });
```

