### PR TITLE
Memory leak fix

### DIFF
--- a/YMChat/src/main/java/com/yellowmessenger/ymchat/YellowBotWebviewFragment.kt
+++ b/YMChat/src/main/java/com/yellowmessenger/ymchat/YellowBotWebviewFragment.kt
@@ -1158,6 +1158,11 @@ class YellowBotWebviewFragment : Fragment() {
         super.onStop()
     }
 
+    override fun onDestroy() {
+        YMChat.getInstance().setLocalListener(null)
+        super.onDestroy()
+    }
+
     companion object {
         fun newInstance(): YellowBotWebviewFragment {
             return YellowBotWebviewFragment()


### PR DESCRIPTION
Setting local listener to null when fragment is getting destroyed to free up memory and enable instance of local listener to garbage collected