### PR TITLE
update/theme-setup

### DIFF
--- a/YMChat/src/main/java/com/yellowmessenger/ymchat/models/YMTheme.java
+++ b/YMChat/src/main/java/com/yellowmessenger/ymchat/models/YMTheme.java
@@ -4,6 +4,7 @@ public class YMTheme {
     public String botName;
     public String primaryColor;
     public String secondaryColor;
+    public String botBubbleBackgroundColor;
     public String botIcon;
     public String botDesc;
     public String botClickIcon;

--- a/app/src/main/java/com/yellowmessenger/ymchatexample/MainActivity.java
+++ b/app/src/main/java/com/yellowmessenger/ymchatexample/MainActivity.java
@@ -108,7 +108,9 @@ public class MainActivity extends AppCompatActivity {
         theme.botDesc = "Demo Bot Description";
         theme.primaryColor = "#000000";
         theme.secondaryColor = "#FFFFFF";
+        theme.botBubbleBackgroundColor = "#0000FF";
         theme.botIcon = "https://cdn.yellowmessenger.com/XJFcMhLpN6L91684914460598.png";
+        theme.botClickIcon = "https://cdn.yellowmessenger.com/XJFcMhLpN6L91684914460598.png";
         ymChat.config.theme = theme;
 
         //setting event listener


### PR DESCRIPTION
- added `setThemeBotBubbleBackgroundColor` method to make change for background color for bot bubble

```java
YMTheme theme = new YMTheme();
theme.botName = "Demo Bot Name";
theme.botDesc = "Demo Bot Description"; 
theme.primaryColor = "#FF0000";
theme.secondaryColor = "#00FF00";
theme.botBubbleBackgroundColor = "#0000FF";
theme.botIcon = "https://cdn.yellowmessenger.com/XJFcMhLpN6L91684914460598.png";
theme.botClickIcon = "https://cdn.yellowmessenger.com/XJFcMhLpN6L91684914460598.png";
ymChat.config.theme = theme;
```

<img src="https://github.com/yellowmessenger/YMChatbot-Android/assets/123462379/6e629f54-7df3-4aef-a3e9-772b25e5ff42"  width="30%" height="30%">
