### PR TITLE
feature/chatBotTheme

### DIFF
--- a/YMChat/src/main/java/com/yellowmessenger/ymchat/models/YMTheme.java
+++ b/YMChat/src/main/java/com/yellowmessenger/ymchat/models/YMTheme.java
@@ -8,4 +8,5 @@ public class YMTheme {
     public String botIcon;
     public String botDesc;
     public String botClickIcon;
+    public String chatBotTheme;
 }

--- a/app/src/main/java/com/yellowmessenger/ymchatexample/MainActivity.java
+++ b/app/src/main/java/com/yellowmessenger/ymchatexample/MainActivity.java
@@ -111,6 +111,7 @@ public class MainActivity extends AppCompatActivity {
         theme.botBubbleBackgroundColor = "#0000FF";
         theme.botIcon = "https://cdn.yellowmessenger.com/XJFcMhLpN6L91684914460598.png";
         theme.botClickIcon = "https://cdn.yellowmessenger.com/XJFcMhLpN6L91684914460598.png";
+        theme.chatBotTheme = "light";
         ymChat.config.theme = theme;
 
         //setting event listener


### PR DESCRIPTION
-  To add custom background color for chat conatiner, 
    - set `chatBotTheme = "light"` or  `chatBotTheme = "dark"` in `YMTheme`
```java
YMTheme theme = new YMTheme();
theme.chatBotTheme = "light"
ymChat.config.theme = theme;
``` 
 -  make sure these properties are added in skin of bot mapping api `chatBotLightThemeBackgroundColor` and `chatBotDarkThemeBackgroundColor` 
```javascript
"skin": {
   ...
   "chatBotLightThemeBackgroundColor": "#F6EACB",
   "chatBotDarkThemeBackgroundColor": "#FF8A8A"
}
```