### PR TITLE
upgrade/AndoridPhotoPicker

### DIFF
--- a/YMChat/build.gradle
+++ b/YMChat/build.gradle
@@ -37,7 +37,7 @@ repositories {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.6.0'
+    implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'com.google.android.material:material:1.3.0'
@@ -45,6 +45,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.activity:activity-ktx:1.6.0'
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'

--- a/YMChat/src/main/AndroidManifest.xml
+++ b/YMChat/src/main/AndroidManifest.xml
@@ -3,10 +3,6 @@
     package="com.yellowmessenger.ymchat">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
-    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO"/>
-    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO"/>
 
     <queries>
 

--- a/YMChat/src/main/java/com/yellowmessenger/ymchat/YellowBotWebviewFragment.kt
+++ b/YMChat/src/main/java/com/yellowmessenger/ymchat/YellowBotWebviewFragment.kt
@@ -446,7 +446,7 @@ class YellowBotWebviewFragment : Fragment() {
                 }
                 mFilePathCallback = filePath as ValueCallback<Array<Uri?>>?
                 isMediaUploadOptionSelected = false
-                showFileChooser()
+                showBottomSheet()
                 return true
             }
 
@@ -550,17 +550,6 @@ class YellowBotWebviewFragment : Fragment() {
         return myWebView
     }
 
-    private fun showFileChooser() {
-        val hideCameraForUpload = ConfigService.getInstance().config.hideCameraForUpload
-        if (hideCameraForUpload || isMultiFileUpload()) {
-            if (context?.let { checkForStoragePermission(it) } == true) {
-                launchFileIntent()
-            }
-        } else {
-            showBottomSheet()
-        }
-    }
-
     private fun showBottomSheet() {
         if (context != null) {
             val bottomSheetDialog = BottomSheetDialog(requireContext())
@@ -568,10 +557,16 @@ class YellowBotWebviewFragment : Fragment() {
             val cameraLayout = bottomSheetDialog.findViewById<LinearLayout>(R.id.camera_layout)
             val galleryLayout = bottomSheetDialog.findViewById<LinearLayout>(R.id.gallery_layout)
             val fileLayout = bottomSheetDialog.findViewById<LinearLayout>(R.id.file_layout)
-            cameraLayout?.setOnClickListener { v: View? ->
-                isMediaUploadOptionSelected = true
-                checkAndLaunchCamera()
-                bottomSheetDialog.dismiss()
+
+            val hideCameraForUpload = ConfigService.getInstance().config.hideCameraForUpload
+            if (hideCameraForUpload) {
+                cameraLayout?.isVisible = false
+            } else {
+                cameraLayout?.setOnClickListener { v: View? ->
+                    isMediaUploadOptionSelected = true
+                    checkAndLaunchCamera()
+                    bottomSheetDialog.dismiss()
+                }
             }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                 galleryLayout?.setOnClickListener { v: View? ->

--- a/YMChat/src/main/java/com/yellowmessenger/ymchat/YellowBotWebviewFragment.kt
+++ b/YMChat/src/main/java/com/yellowmessenger/ymchat/YellowBotWebviewFragment.kt
@@ -414,7 +414,7 @@ class YellowBotWebviewFragment : Fragment() {
                 }
                 mFilePathCallback = filePath as ValueCallback<Array<Uri?>>?
                 isMediaUploadOptionSelected = false
-                showBottomSheet()
+                showFileChooser()
                 return true
             }
 
@@ -517,6 +517,16 @@ class YellowBotWebviewFragment : Fragment() {
         myWebView.loadUrl(newUrl)
         return myWebView
     }
+
+    private fun showFileChooser() {
+        val hideCameraForUpload = ConfigService.getInstance().config.hideCameraForUpload
+        if (hideCameraForUpload && Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            launchFileIntent()
+        } else {
+            showBottomSheet()
+        }
+    }
+
 
     private fun showBottomSheet() {
         if (context != null) {

--- a/YMChat/src/main/java/com/yellowmessenger/ymchat/YellowBotWebviewFragment.kt
+++ b/YMChat/src/main/java/com/yellowmessenger/ymchat/YellowBotWebviewFragment.kt
@@ -543,10 +543,15 @@ class YellowBotWebviewFragment : Fragment() {
             val bottomSheetDialog = BottomSheetDialog(requireContext())
             bottomSheetDialog.setContentView(R.layout.bottom_sheet_dialog_attachment)
             val cameraLayout = bottomSheetDialog.findViewById<LinearLayout>(R.id.camera_layout)
+            val galleryLayout = bottomSheetDialog.findViewById<LinearLayout>(R.id.gallery_layout)
             val fileLayout = bottomSheetDialog.findViewById<LinearLayout>(R.id.file_layout)
             cameraLayout?.setOnClickListener { v: View? ->
                 isMediaUploadOptionSelected = true
                 checkAndLaunchCamera()
+                bottomSheetDialog.dismiss()
+            }
+            galleryLayout?.setOnClickListener {v: View? ->
+                isMediaUploadOptionSelected = true
                 bottomSheetDialog.dismiss()
             }
             fileLayout?.setOnClickListener { v: View? ->

--- a/YMChat/src/main/java/com/yellowmessenger/ymchat/YellowBotWebviewFragment.kt
+++ b/YMChat/src/main/java/com/yellowmessenger/ymchat/YellowBotWebviewFragment.kt
@@ -76,38 +76,6 @@ class YellowBotWebviewFragment : Fragment() {
     private var geoOrigin: String? = null
     private var isMultiFileUpload = false
     private var isBotClosing = false
-    private var storgePermissions = arrayOf(
-        Manifest.permission.READ_EXTERNAL_STORAGE
-    )
-
-    @RequiresApi(api = Build.VERSION_CODES.TIRAMISU)
-    var storgePermission33 = arrayOf(
-        Manifest.permission.READ_MEDIA_IMAGES,
-        Manifest.permission.READ_MEDIA_AUDIO,
-        Manifest.permission.READ_MEDIA_VIDEO
-    )
-
-    private val requestMultiplePermissions = registerForActivityResult(
-        ActivityResultContracts.RequestMultiplePermissions()
-    ) { permissions ->
-        if ((permissions.containsKey(Manifest.permission.READ_MEDIA_IMAGES) && permissions[Manifest.permission.READ_MEDIA_IMAGES] == true)
-            || (permissions.containsKey(Manifest.permission.READ_MEDIA_VIDEO) && permissions[Manifest.permission.READ_MEDIA_VIDEO] == true)
-            || (permissions.containsKey(Manifest.permission.READ_MEDIA_AUDIO) && permissions[Manifest.permission.READ_MEDIA_AUDIO] == true)
-            || (permissions.containsKey(Manifest.permission.READ_EXTERNAL_STORAGE) && permissions[Manifest.permission.READ_EXTERNAL_STORAGE] == true)
-        ) {
-            launchFileIntent()
-        } else {
-            resetFilePathCallback()
-            if (context != null) {
-                YmHelper.showSnackBarWithSettingAction(
-                    requireContext(),
-                    parentLayout,
-                    getString(R.string.ym_message_storgae_permission)
-                )
-            }
-        }
-
-    }
 
     private val requestPermissionLauncher = registerForActivityResult(
         RequestPermission()
@@ -583,7 +551,7 @@ class YellowBotWebviewFragment : Fragment() {
             }
             fileLayout?.setOnClickListener { v: View? ->
                 isMediaUploadOptionSelected = true
-                checkAndLaunchFilePicker()
+                launchFileIntent()
                 bottomSheetDialog.dismiss()
             }
             bottomSheetDialog.setOnDismissListener {
@@ -592,14 +560,6 @@ class YellowBotWebviewFragment : Fragment() {
                 }
             }
             bottomSheetDialog.show()
-        }
-    }
-
-    private fun checkAndLaunchFilePicker() {
-        if (context != null) {
-            if (checkForStoragePermission(requireContext())) {
-                launchFileIntent()
-            }
         }
     }
 
@@ -784,35 +744,6 @@ class YellowBotWebviewFragment : Fragment() {
             storageDir /* directory */
         )
     }
-
-
-    private fun checkForStoragePermission(context: Context): Boolean {
-        val p: Array<String> = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            storgePermission33
-        } else {
-            storgePermissions
-        }
-        return if (hasStoragePermissions(context, p)) {
-            true
-        } else {
-            requestMultiplePermissions.launch(p)
-            false
-        }
-    }
-
-    private fun hasStoragePermissions(context: Context, p: Array<String>): Boolean {
-        p.forEach {
-            if (ContextCompat.checkSelfPermission(
-                    context,
-                    it
-                ) == PackageManager.PERMISSION_GRANTED
-            ) {
-                return true
-            }
-        }
-        return false
-    }
-
 
     fun reload() {
         myWebView.reload()

--- a/YMChat/src/main/java/com/yellowmessenger/ymchat/YellowBotWebviewFragment.kt
+++ b/YMChat/src/main/java/com/yellowmessenger/ymchat/YellowBotWebviewFragment.kt
@@ -25,6 +25,8 @@ import android.view.*
 import android.webkit.*
 import android.webkit.WebView.WebViewTransport
 import android.widget.*
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
 import androidx.annotation.RequiresApi
@@ -32,6 +34,7 @@ import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.core.graphics.drawable.DrawableCompat
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.snackbar.Snackbar
@@ -166,6 +169,8 @@ class YellowBotWebviewFragment : Fragment() {
         }
     }
 
+    private lateinit var photoPickerLauncher: ActivityResultLauncher<PickVisualMediaRequest>
+    private lateinit var multiPhotoPickerLauncher: ActivityResultLauncher<PickVisualMediaRequest>
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setStatusBarColor()
@@ -269,6 +274,24 @@ class YellowBotWebviewFragment : Fragment() {
                 } catch (e: java.lang.Exception) {
                     //Exception Occurred
                 }
+            }
+        }
+
+        photoPickerLauncher = registerForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
+            if (uri != null) {
+                mFilePathCallback!!.onReceiveValue(arrayOf(uri))
+                mFilePathCallback = null
+            } else {
+                resetFilePathCallback()
+            }
+        }
+
+        multiPhotoPickerLauncher = registerForActivityResult(ActivityResultContracts.PickMultipleVisualMedia(5)) { uris: List<Uri> ->
+            if (uris.isNotEmpty()) {
+                mFilePathCallback!!.onReceiveValue(uris.toTypedArray())
+                mFilePathCallback = null
+            } else {
+                resetFilePathCallback()
             }
         }
     }
@@ -550,9 +573,18 @@ class YellowBotWebviewFragment : Fragment() {
                 checkAndLaunchCamera()
                 bottomSheetDialog.dismiss()
             }
-            galleryLayout?.setOnClickListener {v: View? ->
-                isMediaUploadOptionSelected = true
-                bottomSheetDialog.dismiss()
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                galleryLayout?.setOnClickListener { v: View? ->
+                    isMediaUploadOptionSelected = true
+                    if (isMultiFileUpload()) {
+                        multiPhotoPickerLauncher.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageAndVideo))
+                    } else {
+                        photoPickerLauncher.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageAndVideo))
+                    }
+                    bottomSheetDialog.dismiss()
+                }
+            } else {
+                galleryLayout?.isVisible = false
             }
             fileLayout?.setOnClickListener { v: View? ->
                 isMediaUploadOptionSelected = true

--- a/YMChat/src/main/res/drawable/ic_image_ym.xml
+++ b/YMChat/src/main/res/drawable/ic_image_ym.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:autoMirrored="true"
+    android:tint="@color/ym_icon_color"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M21,19V5c0,-1.1 -0.9,-2 -2,-2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2zM8.5,13.5l2.5,3.01L14.5,12l4.5,6H5l3.5,-4.5z" />
+</vector>

--- a/YMChat/src/main/res/layout/bottom_sheet_dialog_attachment.xml
+++ b/YMChat/src/main/res/layout/bottom_sheet_dialog_attachment.xml
@@ -44,6 +44,26 @@
         </LinearLayout>
 
         <LinearLayout
+            android:id="@+id/gallery_layout"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:orientation="vertical">
+
+            <ImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:src="@drawable/ic_image_ym" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/ym_title_gallery" />
+        </LinearLayout>
+
+        <LinearLayout
             android:id="@+id/file_layout"
             android:layout_width="0dp"
             android:layout_height="wrap_content"

--- a/YMChat/src/main/res/values/strings.xml
+++ b/YMChat/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="ym_fab_voice_button">voice button</string>
     <string name="application_id_for_provider">com.yellowmessenger.ymchatexample.fileprovider</string>
     <string name="ym_title_camera">Camera</string>
+    <string name="ym_title_gallery">Gallery</string>
     <string name="ym_title_file">File</string>
     <string name="ym_title_choose_option">Choose Option</string>
     <string name="ym_text_settings">Settings</string>


### PR DESCRIPTION
- PhotoPicker added for Android 11 (API level 30) or higher
- removed storage permissions

#### Example: Android 11 (API level 30) or higher
<img src = "https://github.com/user-attachments/assets/ad15850f-14df-444c-93ee-84336a662a46" width="200px" />
<img src = "https://github.com/user-attachments/assets/8d70d945-c3ea-4095-8348-4565b0af048e" width="200px" />

#### Example: Android API level 28
<img src = "https://github.com/user-attachments/assets/2c8a27a4-d5e5-46f7-a65c-298577159ac3" width="200px" />
