### PR TITLE
Remove multi-file upload check from file chooser

### DIFF
--- a/YMChat/src/main/java/com/yellowmessenger/ymchat/YellowBotWebviewFragment.kt
+++ b/YMChat/src/main/java/com/yellowmessenger/ymchat/YellowBotWebviewFragment.kt
@@ -601,7 +601,7 @@ class YellowBotWebviewFragment : Fragment() {
 
     private fun showFileChooser() {
         val hideCameraForUpload = ConfigService.getInstance().config.hideCameraForUpload
-        if (hideCameraForUpload || isMultiFileUpload()) {
+        if (hideCameraForUpload) {
             if (context != null) {
                 launchFileIntent()
             }


### PR DESCRIPTION
Simplifies the showFileChooser logic by removing the isMultiFileUpload() condition. Now, file chooser is launched only if hideCameraForUpload is true.