### PR TITLE
Fix: Android 16 back gesture handling in YellowBotWebViewActivity

### DIFF
--- a/YMChat/src/main/java/com/yellowmessenger/ymchat/YellowBotWebViewActivity.kt
+++ b/YMChat/src/main/java/com/yellowmessenger/ymchat/YellowBotWebViewActivity.kt
@@ -5,6 +5,7 @@ import android.os.Build
 import android.os.Bundle
 import android.view.View
 import android.view.WindowInsets
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
@@ -17,6 +18,27 @@ class YellowBotWebViewActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_yellow_bot_web_view)
         loadFragment()
+
+        // Register OnBackPressedCallback for Predictive Back Navigation support (Android 16+)
+        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                try {
+                    if (supportFragmentManager.backStackEntryCount == 1) {
+                        YMChat.getInstance().emitEvent(YMBotEventResponse("bot-closed", "", false))
+                        finish()
+                    } else {
+                        // Temporarily disable this callback and trigger the default behavior
+                        // to allow fragment back stack handling
+                        isEnabled = false
+                        onBackPressedDispatcher.onBackPressed()
+                        isEnabled = true
+                    }
+                } catch (e: Exception) {
+                    // Some problem occurred please relaunch the bot
+                    finish()
+                }
+            }
+        })
 
         if (Build.VERSION.SDK_INT > Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
             val rootView = findViewById<View>(R.id.container)
@@ -55,20 +77,5 @@ class YellowBotWebViewActivity : AppCompatActivity() {
         transaction.replace(R.id.container, YellowBotWebviewFragment.newInstance())
         transaction.addToBackStack(null)
         transaction.commit()
-    }
-
-    override fun onBackPressed() {
-        try {
-            if (supportFragmentManager.backStackEntryCount == 1) {
-                YMChat.getInstance().emitEvent(YMBotEventResponse("bot-closed", "", false))
-                finish()
-            } else {
-                super.onBackPressed()
-            }
-        } catch (e: Exception) {
-            //Some problem occurred please relaunch the bot
-            finish()
-
-        }
     }
 }

--- a/YMChat/src/main/java/com/yellowmessenger/ymchat/YellowBotWebviewFragment.kt
+++ b/YMChat/src/main/java/com/yellowmessenger/ymchat/YellowBotWebviewFragment.kt
@@ -169,7 +169,7 @@ class YellowBotWebviewFragment : Fragment() {
                         YMChat.getInstance().emitEvent(YMBotEventResponse("bot-closed", "", false))
                         if (activity is YellowBotWebViewActivity) {
                             closeBot()
-                            activity?.onBackPressed()
+                            activity?.onBackPressedDispatcher?.onBackPressed()
                             isBotClosing = true
                         }
                     }
@@ -340,7 +340,7 @@ class YellowBotWebviewFragment : Fragment() {
             YMChat.getInstance().emitEvent(YMBotEventResponse("bot-closed", "", false))
             if (activity is YellowBotWebViewActivity) {
                 closeBot()
-                activity?.onBackPressed()
+                activity?.onBackPressedDispatcher?.onBackPressed()
                 isBotClosing = true
             }
         }
@@ -1023,7 +1023,7 @@ class YellowBotWebviewFragment : Fragment() {
         if (ConfigService.getInstance().config.botId == null || ConfigService.getInstance().config.botId.trim()
                 .isEmpty()
         ) {
-            activity?.onBackPressed()
+            activity?.onBackPressedDispatcher?.onBackPressed()
         }
         if (shouldKeepApplicationInBackground && (isAgentConnected || ConfigService.getInstance().config.alwaysReload)) {
             reload()

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
         minSdkVersion 21
         targetSdk 36
         versionCode 1
-        versionName "2.26.0"
+        versionName "2.26.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## Problem
The SDK was using the deprecated `onBackPressed()` override in `YellowBotWebViewActivity`, which is bypassed in Android 16 (API 36) with Predictive Back Navigation enabled. This caused the activity to remain in a "blank" state when users performed back gestures, requiring a second gesture to close the activity.

## Root Cause
As of Android 16 (API 36), the system no longer calls `onBackPressed()` for apps targeting the latest SDK to support Predictive Back Navigation. The SDK's back navigation logic was being bypassed entirely, preventing proper cleanup and event emission.

## Solution
Migrated to the `OnBackPressedDispatcher` API, which is the recommended approach for handling back navigation in modern Android versions:

1. **YellowBotWebViewActivity**: Replaced `onBackPressed()` override with `OnBackPressedCallback` registration in `onCreate()`
2. **YellowBotWebviewFragment**: Updated all `activity?.onBackPressed()` calls to use `activity?.onBackPressedDispatcher?.onBackPressed()`

## Changes Made
- ✅ Removed deprecated `onBackPressed()` override from `YellowBotWebViewActivity`
- ✅ Added `OnBackPressedCallback` registration using `onBackPressedDispatcher`
- ✅ Updated fragment calls to use `onBackPressedDispatcher` API (3 locations)
- ✅ Maintained identical behavior and logic flow for backward compatibility

## Backward Compatibility
- ✅ Works on all supported Android versions (API 21+)
- ✅ No breaking changes - maintains same behavior as original implementation
- ✅ No additional dependencies required (uses existing `AppCompatActivity`)