### PR TITLE
Add public stopVoiceMode() API and bump version to 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v3.2.0](https://github.com/yellowmessenger/YMChatbot-Android/releases/tag/v3.2.0) (2026-05-08)
+
+### New Update 🚀
+* Added `stopVoiceMode()` public API on `YMChat` to allow host apps to explicitly stop voice mode — useful when presenting a dialog or bottom sheet over the chatbot where `onStop` is not called.
+
+---
+
 ## [v1.0.0](https://github.com/yellowmessenger/YMChatbot-Android/releases/tag/v1.0.0)
 
 ### Added

--- a/YMChat/src/main/java/com/yellowmessenger/ymchat/YMChat.java
+++ b/YMChat/src/main/java/com/yellowmessenger/ymchat/YMChat.java
@@ -165,6 +165,10 @@ public class YMChat {
         }
     }
 
+    public void stopVoiceMode() {
+        emitLocalEvent(new YMBotEventResponse("stop-voice-mode", "", false));
+    }
+
     public void closeBot() {
         if (localListener != null)
             localListener.onSuccess(new YMBotEventResponse("close-bot", "", false));

--- a/YMChat/src/main/java/com/yellowmessenger/ymchat/YellowBotWebviewFragment.kt
+++ b/YMChat/src/main/java/com/yellowmessenger/ymchat/YellowBotWebviewFragment.kt
@@ -269,6 +269,13 @@ class YellowBotWebviewFragment : Fragment() {
                 } catch (e: java.lang.Exception) {
                     //Exception Occurred
                 }
+                "stop-voice-mode" -> try {
+                    activity?.runOnUiThread {
+                        stopVoiceMode()
+                    }
+                } catch (e: java.lang.Exception) {
+                    //Exception Occurred
+                }
                 "pwa-loaded"-> try {
                     activity?.runOnUiThread {
                         isWebViewReady = true
@@ -1243,6 +1250,21 @@ class YellowBotWebviewFragment : Fragment() {
             }
         }
     }
+
+    fun stopVoiceMode() {
+        if (context == null) return
+        val voiceArea: RelativeLayout = parentLayout.findViewById(R.id.voiceArea)
+        val micButton: YmMovableFloatingActionButton = parentLayout.findViewById(R.id.floatingActionButton)
+        if (voiceArea.visibility == View.VISIBLE) {
+            voiceArea.visibility = View.INVISIBLE
+            micButton.setImageDrawable(AppCompatResources.getDrawable(requireContext(), R.drawable.ic_mic_ym_small))
+            sr?.stopListening()
+        }
+        if (isWebViewReady) {
+            sendEvent(getString(R.string.ym_chat_bot_background_event), "")
+        }
+    }
+
 
     fun closeVoiceArea() {
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
         minSdkVersion 21
         targetSdk 36
         versionCode 1
-        versionName "3.1.0"
+        versionName "3.2.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
Exposes stopVoiceMode() on YMChat singleton so host apps can explicitly stop voice mode when showing a dialog/bottom sheet over the chatbot, where onStop is not called. Hides the voice area UI, stops the speech recognizer, and fires chatbot-in-background to the WebView.