### PR TITLE
Fix WebView JS bridge URL scheme validation and external link handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v3.3.1](https://github.com/yellowmessenger/YMChatbot-Android/releases/tag/v3.3.1) (2026-07-23)
+
+### Security 🔒
+* Restricted the WebView JS bridge's `loadURL()` to `http`/`https` schemes, closing off `javascript:`, `file:`, `data:`, and `content:` URLs.
+* Fixed link handling so `shouldOpenLinkExternally` (default `true`) correctly opens links in the system browser instead of loading them in the in-app WebView.
+* Disabled WebView file-system access (`allowFileAccess`) since it is not required for normal operation.
+
+---
+
 ## [v3.3.0](https://github.com/yellowmessenger/YMChatbot-Android/releases/tag/v3.3.0) (2026-05-19)
 
 ### New Update 🚀

--- a/YMChat/src/main/java/com/yellowmessenger/ymchat/YellowBotWebviewFragment.kt
+++ b/YMChat/src/main/java/com/yellowmessenger/ymchat/YellowBotWebviewFragment.kt
@@ -412,7 +412,7 @@ class YellowBotWebviewFragment : Fragment() {
         myWebView.settings.domStorageEnabled = true
         myWebView.settings.setSupportMultipleWindows(true)
         myWebView.settings.javaScriptCanOpenWindowsAutomatically = true
-        myWebView.settings.allowFileAccess = true
+        myWebView.settings.allowFileAccess = false
         myWebView.settings.setGeolocationDatabasePath(context?.filesDir?.path)
         myWebView.settings.mediaPlaybackRequiresUserGesture = false
         myWebView.addJavascriptInterface(
@@ -451,11 +451,22 @@ class YellowBotWebviewFragment : Fragment() {
                 view: WebView?,
                 request: WebResourceRequest?
             ): Boolean {
-                if (ConfigService.getInstance().config.shouldOpenLinkExternally) {
-                    return super.shouldOverrideUrlLoading(view, request)
-                } else {
-                    emitUrlClickEvent(request?.url.toString())
+                val url = request?.url
+                val scheme = url?.scheme?.lowercase(Locale.ROOT)
+                if (scheme != "http" && scheme != "https") {
+                    // Block javascript:, file:, data:, content: and any other non-http(s) navigation
                     return true
+                }
+                return if (ConfigService.getInstance().config.shouldOpenLinkExternally) {
+                    try {
+                        startActivity(Intent(Intent.ACTION_VIEW, url))
+                    } catch (e: Exception) {
+                        //Some error occurred
+                    }
+                    true
+                } else {
+                    emitUrlClickEvent(url.toString())
+                    true
                 }
             }
         }

--- a/YMChat/src/main/java/com/yellowmessenger/ymchat/models/JavaScriptInterface.java
+++ b/YMChat/src/main/java/com/yellowmessenger/ymchat/models/JavaScriptInterface.java
@@ -1,13 +1,20 @@
 package com.yellowmessenger.ymchat.models;
 
 import android.app.Activity;
+import android.net.Uri;
 import android.webkit.JavascriptInterface;
 import android.webkit.WebView;
 
 import com.google.gson.Gson;
 import com.yellowmessenger.ymchat.YMChat;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
 public class JavaScriptInterface {
+    private static final List<String> ALLOWED_URL_SCHEMES = Arrays.asList("http", "https");
+
     protected Activity parentActivity;
     protected WebView mWebView;
 
@@ -19,6 +26,13 @@ public class JavaScriptInterface {
 
     @JavascriptInterface
     public void loadURL(String url) {
+        if (url == null) {
+            return;
+        }
+        String scheme = Uri.parse(url).getScheme();
+        if (scheme == null || !ALLOWED_URL_SCHEMES.contains(scheme.toLowerCase(Locale.ROOT))) {
+            return;
+        }
         final String u = url;
 
         parentActivity.runOnUiThread(new Runnable() {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
         minSdkVersion 21
         targetSdk 36
         versionCode 1
-        versionName "3.3.0"
+        versionName "3.3.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## Summary
- Restricts `JavaScriptInterface.loadURL()` to `http`/`https` schemes, so calls from the web content bridge (`window.YMHandler.loadURL(...)`) can no longer pass `javascript:`, `file:`, `data:`, or `content:` URLs into `WebView.loadUrl()`.
- Fixes `shouldOverrideUrlLoading()` so `shouldOpenLinkExternally = true` (the default) actually opens links via `Intent.ACTION_VIEW` in the system browser, instead of loading them in the in-app WebView as it was doing before.
- Disables `allowFileAccess` on the WebView, since it isn't needed for normal operation and previously allowed reads of arbitrary local files if combined with the above.
- Bumps version to `3.3.1` and adds a changelog entry (patch release — bug/security fix only, no API changes).

## Why
Addresses a validated bug bounty report (tracked as ISS-15626): a malicious link sent in chat could, once tapped, execute arbitrary JS with full app privileges via the exposed `YMHandler` bridge and read the app's private files, enabling token/cookie theft and account takeover.

## Test plan
- [x] `:YMChat:compileDebugKotlin` and `:YMChat:compileDebugJavaWithJavac` build clean.
- [ ] Manual check: tapping an `http(s)` link in chat opens the system browser instead of navigating in-WebView.
- [ ] Manual check: normal chat/file-upload flows still work with `allowFileAccess = false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)