### PR TITLE
Fix scheme allowlist and allowFileAccess gap in popup WebView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v3.3.2](https://github.com/yellowmessenger/YMChatbot-Android/releases/tag/v3.3.2) (2026-07-23)
+
+### Security 🔒
+* Closed a residual gap from the `v3.3.1` fix: the popup WebView opened via `window.open()`/`target=_blank` (`onCreateWindow`) had no scheme allowlist and did not have `allowFileAccess` disabled, since it's a separate WebView instance that doesn't inherit the main WebView's settings. Now enforces the same `http`/`https`-only scheme allowlist and disables `allowFileAccess` on the popup WebView.
+
+---
+
 ## [v3.3.1](https://github.com/yellowmessenger/YMChatbot-Android/releases/tag/v3.3.1) (2026-07-23)
 
 ### Security 🔒

--- a/YMChat/src/main/java/com/yellowmessenger/ymchat/YellowBotWebviewFragment.kt
+++ b/YMChat/src/main/java/com/yellowmessenger/ymchat/YellowBotWebviewFragment.kt
@@ -548,6 +548,7 @@ class YellowBotWebviewFragment : Fragment() {
                 resultMsg: Message
             ): Boolean {
                 val newWebView = context?.let { WebView(it) }
+                newWebView?.settings?.allowFileAccess = false
                 val transport = resultMsg.obj as WebViewTransport
                 transport.webView = newWebView
                 resultMsg.sendToTarget()
@@ -557,6 +558,11 @@ class YellowBotWebviewFragment : Fragment() {
                             view: WebView?,
                             request: WebResourceRequest?
                         ): Boolean {
+                            val scheme = request?.url?.scheme?.lowercase(Locale.ROOT)
+                            if (scheme != "http" && scheme != "https") {
+                                // Block javascript:, file:, data:, content: and any other non-http(s) navigation
+                                return true
+                            }
                             if (ConfigService.getInstance().config.shouldOpenLinkExternally) {
                                 try {
                                     val browserIntent = Intent(Intent.ACTION_VIEW)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
         minSdkVersion 21
         targetSdk 36
         versionCode 1
-        versionName "3.3.1"
+        versionName "3.3.2"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## Summary
- The `v3.3.1` fix (ISS-15626) applied an http(s)-only scheme allowlist and `allowFileAccess = false` to the main WebView (`myWebView`), but not to the popup WebView created in `onCreateWindow` (the `window.open()` / `target=_blank` path).
- `onCreateWindow` creates a brand-new `WebView` instance (`WebView(it)`) that does not inherit the parent's settings. Its `shouldOverrideUrlLoading` had no scheme check at all: when `shouldOpenLinkExternally` is `false`, it returned `false`, letting `javascript:`, `file:`, `data:`, or any other scheme load directly in that popup WebView. `allowFileAccess` was also left at Android's version/targetSdk-dependent default instead of being explicitly disabled.
- Fix: added the same http(s)-only scheme guard used in the main `WebViewClient` (blocks non-http(s) schemes outright before either the external-open or in-page-load branches run), and set `allowFileAccess = false` on the popup WebView right after creation.

## Why
Follow-up from the original bug bounty report (ISS-15626) — the reporter flagged that this popup path was still open even after `v3.3.1` shipped. Confirmed both gaps by inspection: the `shouldOpenLinkExternally = true` branch was already safe (always routes through `Intent.ACTION_VIEW`, never loads in-WebView), but the `else` branch and the missing `allowFileAccess` setting on the popup WebView were real, unaddressed instances of the same vulnerability class.

## Test plan
- [x] `:YMChat:compileDebugKotlin` builds clean.
- [ ] Manual check: a chat message that opens a popup (`target=_blank`/`window.open()`) pointing at a `javascript:`/`file:` URL is blocked instead of loading in the popup WebView.
- [ ] Manual check: normal `target=_blank` http(s) popups still behave as before (open externally when `shouldOpenLinkExternally` is true, forward `url-clicked` otherwise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)