### PR TITLE
Keep screen awake during Voice Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v3.4.0](https://github.com/yellowmessenger/YMChatbot-Android/releases/tag/v3.4.0) (2026-08-06)
+
+### New Update 🚀
+* Added automatic screen-awake handling during Voice Mode: the SDK now keeps the device screen on for the duration of an active voice conversation (driven by `voice-mode-started`/`voice-mode-ended` events from the web widget) and restores normal screen-timeout behavior as soon as the call ends.
+
+---
+
 ## [v3.3.2](https://github.com/yellowmessenger/YMChatbot-Android/releases/tag/v3.3.2) (2026-07-23)
 
 ### Security 🔒

--- a/YMChat/src/main/java/com/yellowmessenger/ymchat/YellowBotWebviewFragment.kt
+++ b/YMChat/src/main/java/com/yellowmessenger/ymchat/YellowBotWebviewFragment.kt
@@ -277,6 +277,20 @@ class YellowBotWebviewFragment : Fragment() {
                 } catch (e: java.lang.Exception) {
                     //Exception Occurred
                 }
+                "voice-mode-started" -> try {
+                    activity?.runOnUiThread {
+                        acquireVoiceScreenWakeLock()
+                    }
+                } catch (e: java.lang.Exception) {
+                    //Exception Occurred
+                }
+                "voice-mode-ended" -> try {
+                    activity?.runOnUiThread {
+                        releaseVoiceScreenWakeLock()
+                    }
+                } catch (e: java.lang.Exception) {
+                    //Exception Occurred
+                }
                 "pwa-loaded"-> try {
                     activity?.runOnUiThread {
                         isWebViewReady = true
@@ -1296,6 +1310,26 @@ class YellowBotWebviewFragment : Fragment() {
         }
     }
 
+    private var isVoiceScreenWakeLockActive = false
+
+    /**
+     * Keeps the screen on while Voice Mode is active, driven by "voice-mode-started"/
+     * "voice-mode-ended" events from the web widget. Uses the activity window flag
+     * (not PowerManager.WakeLock) so it needs no extra permission and is auto-scoped
+     * to this activity.
+     */
+    private fun acquireVoiceScreenWakeLock() {
+        if (isVoiceScreenWakeLockActive) return
+        activity?.window?.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        isVoiceScreenWakeLockActive = true
+    }
+
+    private fun releaseVoiceScreenWakeLock() {
+        if (!isVoiceScreenWakeLockActive) return
+        activity?.window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        isVoiceScreenWakeLockActive = false
+    }
+
     fun stopVoiceMode() {
         if (context == null) return
         val voiceArea: RelativeLayout = parentLayout.findViewById(R.id.voiceArea)
@@ -1378,6 +1412,7 @@ class YellowBotWebviewFragment : Fragment() {
     }
 
     override fun onStop() {
+        releaseVoiceScreenWakeLock()
         if (shouldKeepApplicationInBackground && (isAgentConnected || ConfigService.getInstance().config.alwaysReload)) {
             updateAgentStatus("offline")
         }
@@ -1397,6 +1432,7 @@ class YellowBotWebviewFragment : Fragment() {
     }
 
     override fun onDestroy() {
+        releaseVoiceScreenWakeLock()
         YMChat.getInstance().clearLocalListener()
         super.onDestroy()
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
         minSdkVersion 21
         targetSdk 36
         versionCode 1
-        versionName "3.3.2"
+        versionName "3.4.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## Summary
- Adds `acquireVoiceScreenWakeLock()`/`releaseVoiceScreenWakeLock()` using `FLAG_KEEP_SCREEN_ON` on the activity window (no extra permission needed).
- Driven by new `voice-mode-started`/`voice-mode-ended` bridge events from the web widget (companion PR in web-app), with safety-net release in `onStop()`/`onDestroy()`.

## Test plan
- [x] `./gradlew :YMChat:compileDebugKotlin` — clean
- [ ] Manual: start Voice Mode in a voice-enabled bot, confirm screen doesn't dim/lock during the call, and returns to normal on call end, app backgrounding, and activity teardown mid-call